### PR TITLE
Provided devcontainer support in template.

### DIFF
--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,0 +1,31 @@
+{
+    "name": "Elixir Development Container",
+    "build": {
+      "dockerfile": ".devcontainer/Dockerfile",
+      "args": {
+        "MIX_ENV": "dev"
+      }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "jakebecker.elixir-ls",         // Elixir Language Server for code completion, diagnostics, and formatting
+                "ms-azuretools.vscode-docker",  // Docker extension for easy container management
+                "editorconfig.editorconfig",    // EditorConfig for consistent coding styles
+                "eamodio.gitlens",              // GitLens for Git history, blame, and insights
+                "streetsidesoftware.code-spell-checker", // Spell checker for comments and documentation
+                "esbenp.prettier-vscode"        // Prettier for consistent formatting, useful if working with front-end code in the project
+              ],
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash"
+            }
+        }
+    },
+    "postCreateCommand": "mix deps.get",
+    "remoteUser": "vscode",
+    "mounts": [
+      "source=${localWorkspaceFolder},target=/workspace,type=bind"
+    ],
+    "workspaceFolder": "/workspace"
+  }
+  

--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,31 +1,29 @@
 {
-    "name": "Elixir Development Container",
-    "build": {
-      "dockerfile": ".devcontainer/Dockerfile",
-      "args": {
-        "MIX_ENV": "dev"
+  "name": "Elixir Kickoff Development Container",
+  "image": "ghcr.io/elixir-journey/elixir-kickoff:latest",
+  "remoteEnv": {
+    "MIX_ENV": "dev"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "jakebecker.elixir-ls", // Elixir Language Server for code completion, diagnostics, and formatting
+        "ms-azuretools.vscode-docker", // Docker extension for easy container management
+        "editorconfig.editorconfig", // EditorConfig for consistent coding styles
+        "eamodio.gitlens", // GitLens for Git history, blame, and insights
+        "streetsidesoftware.code-spell-checker", // Spell checker for comments and documentation
+        "esbenp.prettier-vscode", // Prettier for consistent formatting, useful if working with front-end code in the project
+        "pkief.material-icon-theme"
+      ],
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
       }
-    },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "jakebecker.elixir-ls",         // Elixir Language Server for code completion, diagnostics, and formatting
-                "ms-azuretools.vscode-docker",  // Docker extension for easy container management
-                "editorconfig.editorconfig",    // EditorConfig for consistent coding styles
-                "eamodio.gitlens",              // GitLens for Git history, blame, and insights
-                "streetsidesoftware.code-spell-checker", // Spell checker for comments and documentation
-                "esbenp.prettier-vscode"        // Prettier for consistent formatting, useful if working with front-end code in the project
-              ],
-            "settings": {
-                "terminal.integrated.shell.linux": "/bin/bash"
-            }
-        }
-    },
-    "postCreateCommand": "mix deps.get",
-    "remoteUser": "vscode",
-    "mounts": [
-      "source=${localWorkspaceFolder},target=/workspace,type=bind"
-    ],
-    "workspaceFolder": "/workspace"
-  }
-  
+    }
+  },
+  "postCreateCommand": "mix deps.get",
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspace,type=bind"
+  ],
+  "workspaceFolder": "/workspace"
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,7 @@ RUN mix do local.hex --force, local.rebar --force \
     curl \
     inotify-tools \
     bash \
+    openssh \
     postgresql-client
 
 # Set up the application directory

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,32 @@
+# Use an official Elixir image as the base
+FROM elixir:1.17-alpine
+
+# Set default environment to development
+ENV MIX_ENV=dev
+
+# Install Hex, Rebar, and essential tools
+RUN mix do local.hex --force, local.rebar --force \
+    && apk add --no-cache \
+    git \
+    nodejs \
+    npm \
+    curl \
+    inotify-tools \
+    bash \
+    postgresql-client
+
+# Set up the application directory
+WORKDIR /workspace
+
+# Copy mix files and install dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+
+# Copy the rest of the application code
+COPY . .
+
+# Run compilation in development mode
+RUN mix compile
+
+# Default command to keep container running for VS Code
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,25 +2,15 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
 	"name": "Existing Dockerfile",
-	"build": {
-		// Sets the run context to one level up instead of the .devcontainer folder.
-		"context": "..",
-		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-		"dockerfile": "Dockerfile"
-	}
-
+	"image": "ghcr.io/elixir-journey/elixir-kickoff:latest"
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "cat /etc/os-release",
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "devcontainer"
 }


### PR DESCRIPTION
So why did I take some time to add support for a development container in the kickoff template? I would advise taking a look here quickly: https://containers.dev

I'll sum up a few benefits:
- A devcontainer ensures that everyone working on the project uses the same dependencies, versions, and tools. 
- Devcontainers automate setup steps (installing dependencies, setting up tools, etc.), which saves time and minimizes human error.
- Since devcontainers can be based on Docker images, the same environment can often be used in CI/CD pipelines, ensuring that your CI environment matches your development environment closely.

More than these mere benefits, I took some (as a means to learn because I never did that before) to add support for a pre-built image for the environment.

What does that bring on top of a devcontainer?

If your Dockerfile installs Elixir, Erlang, and some other dependencies and takes around 10 seconds to build, every time you open a new Dev Container, VS Code will spend 10 seconds (on my machine) or more rebuilding it. This delay applies every time you open or rebuild your environment. 

It might feel small, but let's say a company with 500 engineers uses this template. They open it and perhaps restart it 3- 5 times a day. And they work on this given project full-time.

waiting time: 10 seconds
Average IDE restarts: 4
Number of engineers in the development team: 500 engineers in the company
Work days in the year: Let's assume with vacation, 200 days per engineer

Time wasted total = 10 seconds * 4 restarts * 500 engineers * 200 days = 4,000,000 seconds or 1111h+ per year.

We could even extend this example to discuss the number of builds that occur and the resources wasted when we build an environment for the CI if we could instead use a pre-built environment.

If you’ve built and pushed an image with all dependencies installed, VS Code can pull it and start the container almost instantly. Instead of waiting for the 10-second build, your setup time drops to 1-3 seconds if the image is cached or 5-10 seconds if it’s a fresh pull from the registry.

- Time Savings: You eliminate the build time on each start-up, saving 70–90% of the setup time.
- Consistency: Your environment remains the same across sessions or for anyone using the same image.

Let's ignore the CI pipelines and focus on these engineers.  Let's go back to our prior example. What's the impact of the pre-built image here? Let's assume that the fresh pull was already made and that it takes 2 seconds on average to get a working setup.

2 seconds * 4 restarts * 500 engineers * 200 days = 22h+ or an 80% reduction in just setup time. It's quite a big example, but it helps set the tone for why this is a good practice to embrace, especially for a huge body of engineers dependent on this solution.