### PR TITLE
Provided an IEx session file

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,21 @@
+IO.puts("Loading your Elixir project...")
+
+# Alias common modules for easier usage
+# Definitely add something that you'd always want access to.
+
+# Import useful modules such as Eco.Query in the future.
+
+# Automatically start the application (if required for testing functionality)
+{:ok, _} = Application.ensure_all_started(:elixir_kickoff)
+
+Mix.env() |> IO.inspect(label: "Environment")
+
+# Add helpers for debugging
+# defmodule IExHelpers do
+#   def debug(data) do
+#     IO.inspect(data, label: "Debug")
+#   end
+# end
+
+# Add a custom welcome message
+IO.puts("Session ready. Get debugging")

--- a/lib/elixir_kickoff_application.ex
+++ b/lib/elixir_kickoff_application.ex
@@ -8,7 +8,7 @@ defmodule ElixirKickoff.Application do
   use Application
 
   def start(_type, _args) do
-    IO.puts("TemplateApplication is running in the container!")
+    IO.puts("Elixir kickoff template is running in the container!")
     # Small delay to ensure flush
     :timer.sleep(100)
     IO.puts("Log message successfully flushed")
@@ -17,7 +17,7 @@ defmodule ElixirKickoff.Application do
       # Define workers and supervisors to be started
     ]
 
-    opts = [strategy: :one_for_one, name: TemplateApplication.Supervisor]
+    opts = [strategy: :one_for_one, name: ElixirKickoff.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule TemplateApplication.MixProject do
+defmodule ElixirKickoff.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :template_application,
+      app: :elixir_kickoff,
       version: "0.1.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,

--- a/test/elixir_kickoff_application_test.exs
+++ b/test/elixir_kickoff_application_test.exs
@@ -1,5 +1,5 @@
 # test/elixir_kickoff_application_test.exs
-defmodule ElixirKickoffApplicationTest do
+defmodule ElixirKickoff.ApplicationTest do
   use ExUnit.Case
 
   @moduledoc """
@@ -8,7 +8,7 @@ defmodule ElixirKickoffApplicationTest do
 
   test "ensures the application starts correctly" do
     # Ensure the application is started, starting it only if necessary
-    case Application.ensure_all_started(:template_application) do
+    case Application.ensure_all_started(:elixir_kickoff) do
       {:ok, _apps} -> assert true
       {:error, {:already_started, _app}} -> assert true
     end


### PR DESCRIPTION
I stumbled on this a few days ago - https://hexdocs.pm/iex/IEx.html#module-the-iex-exs-file

> The code in the chosen .iex.exs file is evaluated line by line in the shell's context, as if each line were being typed in the shell. For instance, any modules that are loaded or variables that are bound in the .iex.exs file will be available in the shell after it has booted.

So, when starting your IEx session, you wouldn't need to run repetitive work in the terminal, such as aliasing, importing, or even scripting the same stuff repeatedly.

When loading the session with the template, here's what you'll get to see:

> Generated elixir_kickoff app
Elixir kickoff template is running in the container!
Log message successfully flushed
Interactive Elixir (1.17.3) - press Ctrl+C to exit (type h() ENTER for help)
Loading your Elixir project...
Environment: :dev
Session ready. Get debugging

This, for me, will be pretty useful, and hopefully, to others using the template for their endeavors. When this PR merges, it'll resolve #25 