### PR TITLE
Added the styling enforcer in the template.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  plugins: [Styler]
 ]

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule ElixirKickoff.MixProject do
       {:dialyxir, "~> 1.1", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:mix_audit, "~> 2.1"},
-      {:sobelow, "~> 0.13.0"}
+      {:sobelow, "~> 0.13.0"},
+      {:styler, "~> 1.2", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -13,6 +13,7 @@
   "mix_audit": {:hex, :mix_audit, "2.1.4", "0a23d5b07350cdd69001c13882a4f5fb9f90fbd4cbf2ebc190a2ee0d187ea3e9", [:make, :mix], [{:jason, "~> 1.4", [hex: :jason, repo: "hexpm", optional: false]}, {:yaml_elixir, "~> 2.11", [hex: :yaml_elixir, repo: "hexpm", optional: false]}], "hexpm", "fd807653cc8c1cada2911129c7eb9e985e3cc76ebf26f4dd628bb25bbcaa7099"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "sobelow": {:hex, :sobelow, "0.13.0", "218afe9075904793f5c64b8837cc356e493d88fddde126a463839351870b8d1e", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "cd6e9026b85fc35d7529da14f95e85a078d9dd1907a9097b3ba6ac7ebbe34a0d"},
+  "styler": {:hex, :styler, "1.2.1", "28f9e3d4b065c22575c56b8ae03d05188add1b21bec5ae664fc1551e2dfcc41b", [:mix], [], "hexpm", "71dc33980e530d21ca54db9c2075e646faa6e7b744a9d4a3dfb0ff01f56595f0"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.11.0", "9e9ccd134e861c66b84825a3542a1c22ba33f338d82c07282f4f1f52d847bd50", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "53cc28357ee7eb952344995787f4bb8cc3cecbf189652236e9b163e8ce1bc242"},
 }

--- a/test/elixir_kickoff_application_test.exs
+++ b/test/elixir_kickoff_application_test.exs
@@ -1,10 +1,10 @@
 # test/elixir_kickoff_application_test.exs
 defmodule ElixirKickoff.ApplicationTest do
-  use ExUnit.Case
-
   @moduledoc """
   Tests for the ElixirKickoff.Application module.
   """
+
+  use ExUnit.Case
 
   test "ensures the application starts correctly" do
     # Ensure the application is started, starting it only if necessary


### PR DESCRIPTION
> It helps remove fiddly code review comments and removes failed linter CI slowdowns, helping teams get things done faster.

Here, I'm trying to leverage existing automations, libraries and tools built by the great Elixir community. In this specific instance, it's about writng good quality code and having tooling that can provide unbiased recommendations. 

Like anything, if the tool becomes too cumbersome, it can be removed at anything. 

Something to pay attention to in the readme of the styler repository:

> Styler was designed for a **large team (40+ engineers) working in a single codebase.

Working on solitary projects, I don't mind recommendations given by the tool. If I change my mind over time, then I may remove it from the dependencies used by the template.