### PR TITLE
Added backwards compatibility for Elixir down to 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,39 @@ on:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Elixir 1.14 combinations
+          - elixir: '1.14'
+            otp: '24'
+          - elixir: '1.14'
+            otp: '25'
+
+          # Elixir 1.15 combinations
+          - elixir: '1.15'
+            otp: '24'
+          - elixir: '1.15'
+            otp: '25'
+          - elixir: '1.15'
+            otp: '26'
+
+          # Elixir 1.16 combinations
+          - elixir: '1.16'
+            otp: '24'
+          - elixir: '1.16'
+            otp: '25'
+          - elixir: '1.16'
+            otp: '26'
+
+          # Elixir 1.17 combinations
+          - elixir: '1.17'
+            otp: '25'
+          - elixir: '1.17'
+            otp: '26'
+          - elixir: '1.17'
+            otp: '27'
+
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -18,8 +51,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.17'
-          otp-version: '27.1.2'
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       - name: Install dependencies
         run: mix deps.get
@@ -35,6 +68,38 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     needs: setup
+    strategy:
+      matrix:
+        include:
+          # Elixir 1.14 combinations
+          - elixir: '1.14'
+            otp: '24'
+          - elixir: '1.14'
+            otp: '25'
+
+          # Elixir 1.15 combinations
+          - elixir: '1.15'
+            otp: '24'
+          - elixir: '1.15'
+            otp: '25'
+          - elixir: '1.15'
+            otp: '26'
+
+          # Elixir 1.16 combinations
+          - elixir: '1.16'
+            otp: '24'
+          - elixir: '1.16'
+            otp: '25'
+          - elixir: '1.16'
+            otp: '26'
+
+          # Elixir 1.17 combinations
+          - elixir: '1.17'
+            otp: '25'
+          - elixir: '1.17'
+            otp: '26'
+          - elixir: '1.17'
+            otp: '27'
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -42,8 +107,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.17'
-          otp-version: '27.1.2'
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       - name: Install dependencies (if not cached)
         run: mix deps.get
@@ -76,6 +141,38 @@ jobs:
   docker-check:
     runs-on: ubuntu-latest
     needs: setup
+    strategy:
+      matrix:
+        include:
+          # Elixir 1.14 combinations
+          - elixir: '1.14'
+            otp: '24'
+          - elixir: '1.14'
+            otp: '25'
+
+          # Elixir 1.15 combinations
+          - elixir: '1.15'
+            otp: '24'
+          - elixir: '1.15'
+            otp: '25'
+          - elixir: '1.15'
+            otp: '26'
+
+          # Elixir 1.16 combinations
+          - elixir: '1.16'
+            otp: '24'
+          - elixir: '1.16'
+            otp: '25'
+          - elixir: '1.16'
+            otp: '26'
+
+          # Elixir 1.17 combinations
+          - elixir: '1.17'
+            otp: '25'
+          - elixir: '1.17'
+            otp: '26'
+          - elixir: '1.17'
+            otp: '27'
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -83,8 +180,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.17'
-          otp-version: '27.1.2'
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       - name: Build Docker Image
         run: |
@@ -93,6 +190,38 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     needs: setup
+    strategy:
+      matrix:
+        include:
+          # Elixir 1.14 combinations
+          - elixir: '1.14'
+            otp: '24'
+          - elixir: '1.14'
+            otp: '25'
+
+          # Elixir 1.15 combinations
+          - elixir: '1.15'
+            otp: '24'
+          - elixir: '1.15'
+            otp: '25'
+          - elixir: '1.15'
+            otp: '26'
+
+          # Elixir 1.16 combinations
+          - elixir: '1.16'
+            otp: '24'
+          - elixir: '1.16'
+            otp: '25'
+          - elixir: '1.16'
+            otp: '26'
+
+          # Elixir 1.17 combinations
+          - elixir: '1.17'
+            otp: '25'
+          - elixir: '1.17'
+            otp: '26'
+          - elixir: '1.17'
+            otp: '27'
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -100,8 +229,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.17'
-          otp-version: '27.1.2'
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       - name: Install dependencies (if not cached)
         run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,21 @@ jobs:
     strategy:
       matrix:
         include:
+          # Elixir 1.13 combinations
+          - elixir: '1.13'
+            otp: '25'
+
           # Elixir 1.14 combinations
-          - elixir: '1.14'
-            otp: '24'
           - elixir: '1.14'
             otp: '25'
 
           # Elixir 1.15 combinations
-          - elixir: '1.15'
-            otp: '24'
           - elixir: '1.15'
             otp: '25'
           - elixir: '1.15'
             otp: '26'
 
           # Elixir 1.16 combinations
-          - elixir: '1.16'
-            otp: '24'
           - elixir: '1.16'
             otp: '25'
           - elixir: '1.16'
@@ -71,23 +69,21 @@ jobs:
     strategy:
       matrix:
         include:
+          # Elixir 1.13 combinations
+          - elixir: '1.13'
+            otp: '25'
+
           # Elixir 1.14 combinations
-          - elixir: '1.14'
-            otp: '24'
           - elixir: '1.14'
             otp: '25'
 
           # Elixir 1.15 combinations
-          - elixir: '1.15'
-            otp: '24'
           - elixir: '1.15'
             otp: '25'
           - elixir: '1.15'
             otp: '26'
 
           # Elixir 1.16 combinations
-          - elixir: '1.16'
-            otp: '24'
           - elixir: '1.16'
             otp: '25'
           - elixir: '1.16'
@@ -144,23 +140,21 @@ jobs:
     strategy:
       matrix:
         include:
+          # Elixir 1.13 combinations
+          - elixir: '1.13'
+            otp: '25'
+
           # Elixir 1.14 combinations
-          - elixir: '1.14'
-            otp: '24'
           - elixir: '1.14'
             otp: '25'
 
           # Elixir 1.15 combinations
-          - elixir: '1.15'
-            otp: '24'
           - elixir: '1.15'
             otp: '25'
           - elixir: '1.15'
             otp: '26'
 
           # Elixir 1.16 combinations
-          - elixir: '1.16'
-            otp: '24'
           - elixir: '1.16'
             otp: '25'
           - elixir: '1.16'
@@ -193,23 +187,21 @@ jobs:
     strategy:
       matrix:
         include:
+          # Elixir 1.13 combinations
+          - elixir: '1.13'
+            otp: '25'
+
           # Elixir 1.14 combinations
-          - elixir: '1.14'
-            otp: '24'
           - elixir: '1.14'
             otp: '25'
 
           # Elixir 1.15 combinations
-          - elixir: '1.15'
-            otp: '24'
           - elixir: '1.15'
             otp: '25'
           - elixir: '1.15'
             otp: '26'
 
           # Elixir 1.16 combinations
-          - elixir: '1.16'
-            otp: '24'
           - elixir: '1.16'
             otp: '25'
           - elixir: '1.16'

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,8 @@ defmodule ElixirKickoff.MixProject do
     [
       app: :elixir_kickoff,
       version: "0.1.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.13",
+      erlang: "~> 25.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: [


### PR DESCRIPTION
The goal here is to enhance the support provided by the CI. Here, we're allowing engineers to test their code across multiple versions of OTP and Elixir. 

The goal of the template is to provide a wide range of support for engineers interested in using the template for their own project. It is entirely possible that a individual / team / company can't use the most recent version of a tool. Showcasing that the template can support their needs and allow work for future versions will keep them prepared for once they make their upgrade (if and when it happens).

By leveraging GitHub Actions' matrix builds, we ensure efficient and parallel testing across these combinations without significantly increasing CI runtime. This change positions the project as robust, future-ready, and user-friendly.
