### PR TITLE
Allow direct GitHub communication in devcontainer

### DIFF
--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -21,9 +21,12 @@
     }
   },
   "postCreateCommand": "mix deps.get",
+  "postStartCommand": "../scripts/post_start.sh",
   "remoteUser": "vscode",
   "mounts": [
-    "source=${localWorkspaceFolder},target=/workspace,type=bind"
+    "source=${localWorkspaceFolder},target=/workspace,type=bind",
+    "source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
   ],
   "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,12 @@ RUN mix do local.hex --force, local.rebar --force \
     openssh \
     postgresql-client
 
+# Install GitHub CLI (gh)
+RUN apk add --no-cache github-cli
+
+# Ensure .ssh directory exists
+RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh
+
 # Set up the application directory
 WORKDIR /workspace
 
@@ -26,8 +32,11 @@ RUN mix deps.get --only $MIX_ENV
 # Copy the rest of the application code
 COPY . .
 
+# Ensure proper permissions for the workspace directory
+RUN chown -R root:root /workspace
+
 # Run compilation in development mode
 RUN mix compile
 
-# Default command to keep container running for VS Code
-CMD ["sleep", "infinity"]
+# Default command for better interactive experience
+CMD ["/bin/bash"]

--- a/scripts/post_start.sh
+++ b/scripts/post_start.sh
@@ -7,72 +7,68 @@ if [ -f .env ]; then
     export $(grep -v '^#' .env | xargs)
     echo "Environment variables loaded from .env"
 else
-    echo "No .env file found"
+    echo "No .env file found. Falling back to defaults."
 fi
 
-# 2. Mount User's Git Configuration
-if [ -f /root/.gitconfig ]; then
-    echo "Git configuration already mounted."
-else
-    echo "Mounting Git configuration..."
-    cp ~/.gitconfig /root/.gitconfig || echo "Failed to mount Git configuration."
-fi
-
-# 3. Dynamically Apply User Configuration
+# 2. Configure Git User
 echo "Applying user Git configuration..."
-git config --global user.name "${GIT_USER_NAME:-$(git config --global user.name || echo 'Unknown User')}"
-git config --global user.email "${GIT_USER_EMAIL:-$(git config --global user.email || echo 'unknown@example.com')}"
+
+# Load user.name from gitconfig, .env, or fallback to "Unknown User"
+GIT_USER_NAME=$(git config --global user.name || echo "${GIT_USER_NAME:-Unknown User}")
+git config --global user.name "$GIT_USER_NAME"
+
+# Load user.email from gitconfig, .env, or fallback to "unknown@example.com"
+GIT_USER_EMAIL=$(git config --global user.email || echo "${GIT_USER_EMAIL:-unknown@example.com}")
+git config --global user.email "$GIT_USER_EMAIL"
+
+# Output the final values
 echo "Git user.name: $(git config --global user.name)"
 echo "Git user.email: $(git config --global user.email)"
 
-# 4. Ensure SSH Keys Are Available
-echo "Setting up SSH agent..."
+# 3. Configure SSH
+echo "Setting up SSH..."
 eval "$(ssh-agent -s)"
-if [ -f ~/.ssh/id_rsa ]; then
-    ssh-add ~/.ssh/id_rsa || echo "Failed to add SSH key."
-    echo "SSH key added successfully."
+if [ "$(ls -A ~/.ssh 2>/dev/null)" ]; then
+    chmod 600 ~/.ssh/*
+    ssh-add ~/.ssh/id_ed25519 2>/dev/null && echo "Added id_ed25519 to SSH agent."
+    ssh-add ~/.ssh/id_rsa 2>/dev/null && echo "Added id_rsa to SSH agent."
 else
-    echo "No SSH key found. Falling back to HTTPS and GitHub CLI."
+    echo "No SSH key found. Please ensure keys are available in ~/.ssh."
+fi
 
-    # 4.1 Install and Authenticate with GitHub CLI
-    if ! command -v gh &> /dev/null; then
-        echo "GitHub CLI (gh) is not installed. Please install it in the container."
-        exit 1
+# 4. Test SSH and Fallback to HTTPS
+echo "Testing SSH connection to GitHub..."
+if ssh -T git@github.com 2>/dev/null; then
+    echo "SSH connection successful."
+else
+    echo "SSH connection failed. Falling back to HTTPS."
+    REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+    if [[ "$REMOTE_URL" == git@* ]]; then
+        HTTPS_URL=$(echo "$REMOTE_URL" | sed -e 's/^git@github.com:/https:\/\/github.com\//')
+        git remote set-url origin "$HTTPS_URL"
+        echo "Updated remote URL to HTTPS: $HTTPS_URL"
     fi
+fi
 
+# 5. Authenticate with GitHub CLI (if available)
+if command -v gh &> /dev/null; then
     echo "Authenticating with GitHub CLI..."
     if [ -z "$GITHUB_TOKEN" ]; then
         echo "No GITHUB_TOKEN found in the environment. Please provide one in the .env file."
         exit 1
     fi
-
     echo "$GITHUB_TOKEN" | gh auth login --with-token || {
         echo "GitHub CLI authentication failed."
         exit 1
     }
     echo "Authenticated with GitHub CLI."
-
-    # 4.2 Convert SSH Remote URL to HTTPS if necessary
-    REMOTE_URL=$(git remote get-url origin 2>/dev/null)
-    if [[ "$REMOTE_URL" == git@* ]]; then
-        echo "Converting SSH remote URL to HTTPS..."
-        HTTPS_URL=$(echo "$REMOTE_URL" | sed -e 's/^git@github.com:/https:\/\/github.com\//')
-        git remote set-url origin "$HTTPS_URL"
-        echo "Updated remote URL to HTTPS: $HTTPS_URL"
-    else
-        echo "Remote URL already using HTTPS or no remote URL set."
-    fi
 fi
 
-# 5. Automate Setting Git Remote URLs (if SSH is available)
-REMOTE_URL=$(git remote get-url origin 2>/dev/null)
-if [[ "$REMOTE_URL" == https://* ]]; then
-    echo "Remote URL already using HTTPS."
-else
-    echo "Ensuring SSH URL is used..."
-    SSH_URL=$(echo "$REMOTE_URL" | sed -e 's/^https:\/\//git@/' -e 's/github.com\//github.com:/')
-    git remote set-url origin "$SSH_URL"
-    echo "Updated remote URL to SSH: $SSH_URL"
+# 6. Add Git Credentials for HTTPS
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "Configuring Git credentials for HTTPS..."
+    git config --global credential.helper store
+    echo "https://$GITHUB_TOKEN@github.com" > ~/.git-credentials
 fi
 
 echo "Post-start configuration complete!"

--- a/scripts/post_start.sh
+++ b/scripts/post_start.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+echo "Starting post-start configuration..."
+
+# 1. Load Environment Variables from `.env`
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+    echo "Environment variables loaded from .env"
+else
+    echo "No .env file found"
+fi
+
+# 2. Mount User's Git Configuration
+if [ -f /root/.gitconfig ]; then
+    echo "Git configuration already mounted."
+else
+    echo "Mounting Git configuration..."
+    cp ~/.gitconfig /root/.gitconfig || echo "Failed to mount Git configuration."
+fi
+
+# 3. Dynamically Apply User Configuration
+echo "Applying user Git configuration..."
+git config --global user.name "${GIT_USER_NAME:-$(git config --global user.name || echo 'Unknown User')}"
+git config --global user.email "${GIT_USER_EMAIL:-$(git config --global user.email || echo 'unknown@example.com')}"
+echo "Git user.name: $(git config --global user.name)"
+echo "Git user.email: $(git config --global user.email)"
+
+# 4. Ensure SSH Keys Are Available
+echo "Setting up SSH agent..."
+eval "$(ssh-agent -s)"
+if [ -f ~/.ssh/id_rsa ]; then
+    ssh-add ~/.ssh/id_rsa || echo "Failed to add SSH key."
+    echo "SSH key added successfully."
+else
+    echo "No SSH key found. Falling back to HTTPS and GitHub CLI."
+
+    # 4.1 Install and Authenticate with GitHub CLI
+    if ! command -v gh &> /dev/null; then
+        echo "GitHub CLI (gh) is not installed. Please install it in the container."
+        exit 1
+    fi
+
+    echo "Authenticating with GitHub CLI..."
+    if [ -z "$GITHUB_TOKEN" ]; then
+        echo "No GITHUB_TOKEN found in the environment. Please provide one in the .env file."
+        exit 1
+    fi
+
+    echo "$GITHUB_TOKEN" | gh auth login --with-token || {
+        echo "GitHub CLI authentication failed."
+        exit 1
+    }
+    echo "Authenticated with GitHub CLI."
+
+    # 4.2 Convert SSH Remote URL to HTTPS if necessary
+    REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+    if [[ "$REMOTE_URL" == git@* ]]; then
+        echo "Converting SSH remote URL to HTTPS..."
+        HTTPS_URL=$(echo "$REMOTE_URL" | sed -e 's/^git@github.com:/https:\/\/github.com\//')
+        git remote set-url origin "$HTTPS_URL"
+        echo "Updated remote URL to HTTPS: $HTTPS_URL"
+    else
+        echo "Remote URL already using HTTPS or no remote URL set."
+    fi
+fi
+
+# 5. Automate Setting Git Remote URLs (if SSH is available)
+REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+if [[ "$REMOTE_URL" == https://* ]]; then
+    echo "Remote URL already using HTTPS."
+else
+    echo "Ensuring SSH URL is used..."
+    SSH_URL=$(echo "$REMOTE_URL" | sed -e 's/^https:\/\//git@/' -e 's/github.com\//github.com:/')
+    git remote set-url origin "$SSH_URL"
+    echo "Updated remote URL to SSH: $SSH_URL"
+fi
+
+echo "Post-start configuration complete!"


### PR DESCRIPTION
Marvelous!

We can now operate in the container and communicate with GitHub.

2 issues arose in development:
- I couldn't mount my SSH public keys in the container
- I couldn't automatically installed the binaries for gh

So in the end, we're falling back to communicating through HTTPS. It's better than before. In the past, I would operate in VS Code for development and switch back to the Terminal on my host machine for committing and interacting with GitHub since the container didn't have the right permissions to do so.

What we'll do is open separate feature tickets to allow for each individual feature to work in the future. I don't want to enforce an engineer/team on how they wish to interact with GitHub. The template is there to enable people and they can decide in which direction that they want to head.